### PR TITLE
fix example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ class MyCheckbox extends Component {
     return (
       <VirtualizedCheckbox
         items={items}
-        onOK={(checkedItems) => this.setState({ checkedItems })}
+        onOk={(checkedItems) => this.setState({ checkedItems })}
         onCancel={ () => this.setState({ checkedItems: [] })}
       />
     )

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ class MyCheckbox extends Component {
 
   render () {
     const items = [
-      { label: "One", value: 1 },
-      { label: "Two", value: 2 },
-      { label: "Three", value: 3 }
+      { label: "One", value: 1, checked: true},
+      { label: "Two", value: 2, checked: true},
+      { label: "Three", value: 3, checked: true}
       // And so on...
     ]
 


### PR DESCRIPTION
Readme has incorrect capitalization of onOk in the example. This confused me for a while. Also adds checked: true to the data in the example which is not mentioned elsewhere.